### PR TITLE
Config: turn ip datatype into string.

### DIFF
--- a/priv/vmq_bridge.schema
+++ b/priv/vmq_bridge.schema
@@ -5,14 +5,14 @@
 %% bridges can configured by using different bridge names (e.g. br0). If the 
 %% connection supports SSL encryption bridge.ssl.<name> can be used.
 {mapping, "bridge.tcp.$name", "vmq_bridge.config", [
-                                                    {default, {"127.0.0.1", 1889}},
-                                                    {datatype, ip},
+                                                    {default, {"127.0.0.1:1889"}},
+                                                    {datatype, string},
                                                     {include_default, "br0"},
                                                     {commented, "127.0.0.1:1889"}
                                                    ]}. 
 {mapping, "bridge.ssl.$name", "vmq_bridge.config", [
-                                                    {default, {"127.0.0.1", 1889}},
-                                                    {datatype, ip},
+                                                    {default, {"127.0.0.1:1889"}},
+                                                    {datatype, string},
                                                     hidden
                                                    ]}. 
 

--- a/src/vmq_bridge.app.src
+++ b/src/vmq_bridge.app.src
@@ -16,7 +16,7 @@
         {config, { 
             [
             %% TCP Bridges
-                %% {{StrIp, Port}, [{clean_session, true|false},
+                %% {StrIp, [{clean_session, true|false},
                 %%                  {client_id, "my_client_id"},
                 %%                  {keepalive_interval, 60},       % seconds
                 %%                  {restart_timeout, 10},          % seconds

--- a/src/vmq_bridge_sup.erl
+++ b/src/vmq_bridge_sup.erl
@@ -52,7 +52,9 @@ change_config(Configs) ->
             stop_and_delete_unused(Bridges, lists:flatten([TCP, SSL]))
     end.
 
-reconfigure_bridges(Type, Bridges, [{{Host, Port}, Opts}|Rest]) ->
+reconfigure_bridges(Type, Bridges, [{HostString, Opts}|Rest]) ->
+    {Host,PortString} = list_to_tuple(string:tokens(HostString, ":")),
+    {Port,_}=string:to_integer(PortString),
     Ref = ref(Host, Port),
     case lists:keyfind(Ref, 1, Bridges) of
         false ->
@@ -84,7 +86,9 @@ start_bridge(Type, Ref, Host, Port, Opts) ->
 
 stop_and_delete_unused(Bridges, Config) ->
     BridgesToDelete =
-    lists:foldl(fun({{Host, Port}, _}, Acc) ->
+    lists:foldl(fun({HostString, _}, Acc) ->
+                        {Host,PortString} = list_to_tuple(string:tokens(HostString, ":")),
+                        {Port,_}=string:to_integer(PortString),
                         Ref = ref(Host, Port),
                         lists:keydelete(Ref, 1, Acc)
                 end, Bridges, Config),

--- a/test/vmq_bridge_tests.erl
+++ b/test/vmq_bridge_tests.erl
@@ -243,7 +243,7 @@ start_bridge_plugin(QoS) ->
     application:set_env(vmq_bridge, config,
                         {[
                           %% TCP Bridges
-                          {{"127.0.0.1", 1890}, [{topics, [{"bridge/#", both, QoS, "", ""}]},
+                          {"127.0.0.1:1890", [{topics, [{"bridge/#", both, QoS, "", ""}]},
                                                  {restart_timeout, 5},
                                                  {client_id, "bridge-test"}]}
                          ],

--- a/test/vmq_bridge_tests.erl
+++ b/test/vmq_bridge_tests.erl
@@ -243,7 +243,7 @@ start_bridge_plugin(QoS) ->
     application:set_env(vmq_bridge, config,
                         {[
                           %% TCP Bridges
-                          {"127.0.0.1:1890", [{topics, [{"bridge/#", both, QoS, "", ""}]},
+                          {"localhost:1890", [{topics, [{"bridge/#", both, QoS, "", ""}]},
                                                  {restart_timeout, 5},
                                                  {client_id, "bridge-test"}]}
                          ],


### PR DESCRIPTION
This way, it becomes possible to connect to a known DNS besides an IP.

Should fix erlio/vernemq#215
